### PR TITLE
Add CI workflow for testing with Python (Backend)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.13']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+      - run: pip install -r requirements.txt
+      - run: pip install pytest pytest-cov
+      - run: pytest -q --junitxml=pytest-report.xml --cov=. --cov-report=xml
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: pytest-report
+          path: pytest-report.xml
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-xml
+          path: coverage.xml


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to enable automated testing and coverage reporting for the project. The workflow runs on pushes to the `main` branch and on pull requests, ensuring that tests and coverage are checked for all major changes.

Continuous Integration setup:

* Added a new workflow file `.github/workflows/main.yml` to run CI on push and pull request events, using Ubuntu and Python 3.13.
* Configured steps to install dependencies, run tests with `pytest` and coverage, and upload test and coverage reports as artifacts.